### PR TITLE
Removing color codes

### DIFF
--- a/palaver.cpp
+++ b/palaver.cpp
@@ -828,6 +828,9 @@ public:
 						device.HasMentionNick(Nick.GetNick()) ||
 						device.IncludesMentionKeyword(sMessage, m_pNetwork->GetIRCNick().GetNick()));
 
+					sMessage.Replace("\x03","");
+					sMessage.Replace("\x0F","");
+
 					if (bMention && (
 							(pChannel && device.HasIgnoreChannel(pChannel->GetName())) ||
 							device.HasIgnoreNick(Nick.GetNick()) ||


### PR DESCRIPTION
When hilighted message has color codes, push notification dosen't work at all. This is realy annoying when using IRC gateway like CraftIRC and it put colorcodes automaticly to every message.

This is not best way to do it (just hotfix), but does job.

sMessage: '<[G]\x0300[\x0309言葉0o\x0300]\x0FPlayer>\x0F nickname, will this work?'
that message didin't work without this fix.
