### PR TITLE
Uses C++11 to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS := -Wno-unknown-pragmas
+CXXFLAGS := -Wno-unknown-pragmas -std=c++11
 PALAVER_VERSION := $(shell git describe --tags --always --dirty 2> /dev/null)
 
 ifneq "$(PALAVER_VERSION)" ""


### PR DESCRIPTION
When trying to build, I encountered several errors complaining about which standard was being used:

```
Building "palaver.so" for ZNC 1.4... In file included from /usr/include/c++/4.9.2/regex:35:0,
                 from palaver.cpp:13:
/usr/include/c++/4.9.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled w
ith the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
palaver.cpp: In function ‘CString re_escape(const CString&)’:
palaver.cpp:46:31: error: range-based ‘for’ loops are not allowed in C++98 mode
  for (const char& character : sString) {
                               ^
palaver.cpp: In member function ‘bool CDevice::IncludesMentionKeyword(const CString&, const CString&) const’:
palaver.cpp:434:4: error: ‘smatch’ is not a member of ‘std’
    std::smatch match;
    ^
palaver.cpp:435:4: error: ‘regex’ is not a member of ‘std’
    std::regex expression = std::regex("\\b" + re_escape(sKeyword) + "\\b",
    ^
palaver.cpp:438:4: error: ‘regex_search’ is not a member of ‘std’
    std::regex_search(sMessage, match, expression);
    ^
palaver.cpp:438:32: error: ‘match’ was not declared in this scope
    std::regex_search(sMessage, match, expression);
                                ^
palaver.cpp:438:39: error: ‘expression’ was not declared in this scope
    std::regex_search(sMessage, match, expression);
                                       ^
[ !! ] Error while building "palaver.so"
Makefile:9: recipe for target 'palaver.so' failed
make: *** [palaver.so] Error 1
```

This commit adds a CXXFLAGS option to use C++11, which fixes all the errors and enables the build to complete successfully.