### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ make
 Copy the compile ZNC module to your ZNC settings:
 
 ```bash
+$ mkdir -p ~/.znc/modules
 $ cp palaver.so ~/.znc/modules
 ```
 


### PR DESCRIPTION
The line `cp palaver.so ~/.znc/modules` was a bit ambiguous and in the case there was no directory `modules` yet, it would create a *file* called modules instead. To circumvent this, I added `mkdir ~/.znc/modules`.