### PR TITLE
Add integration test to verify push notifications are sent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ test/fixtures/modules/palaver.so: palaver.so
 
 .PHONY: test-integration
 test-integration: test/fixtures/modules/palaver.so
-	@mkdir test-reports
+	@mkdir -p test-reports
 	pytest --junitxml=test-reports/junit.xml


### PR DESCRIPTION
Creates a HTTP server and ensures that the expected POST request is received during sending push notification.

I've managed to lower some sleeps for shutting down ZNC to speed up test runs, we now allow 200ms for most ZNC related operations to happen.