### PR TITLE
Clear badgge when Palaver device connects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for Palaver ZNC Module
 
+## 1.2.1 (18/07/2020)
+
+### Bug Fixes
+
+- Fixes a case where the unread badge on send push notifications would not get
+  reset when reconnecting the same Palaver device.
+
 ## 1.2.0
 
 ### Enhancements


### PR DESCRIPTION
The has been a case from the start where if you reconnect the same Palaver device after reciving a push notification, that unread count would only be cleared when another different client connects. This makes it so that we also reset our internal badge count during the same device connecting after notifications.