### PR TITLE
Makefile: use xunit2 as default for pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ test/fixtures/modules/palaver.so: palaver.so
 .PHONY: test-integration
 test-integration: test/fixtures/modules/palaver.so
 	@mkdir -p test-reports
-	pytest --junitxml=test-reports/junit.xml
+	pytest -o junit_family=xunit2 --junitxml=test-reports/junit.xml


### PR DESCRIPTION
PytestDeprecationWarning: The 'junit_family' default
value will change to 'xunit2' in pytest 6.0.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>